### PR TITLE
ci: add build/test/lint workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,47 @@
+name: CI checks
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo fmt -- --check --color always
+
+  test:
+    name: Test on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macOS-latest]
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo test --release --verbose --all-features
+
+  no-std:
+    name: Check no-std target ${{ matrix.target }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        target:
+          - wasm32-unknown-unknown
+          - wasm32-wasip1
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+      - run: cargo build --verbose --target ${{ matrix.target }} --all-features --lib


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/ci.yml` with three jobs mirroring the sister `ibe` crate: `lint` (cargo fmt), `test` (release + all-features on ubuntu/windows/macOS), and `no-std` (`cargo build --lib` for `wasm32-unknown-unknown` and `wasm32-wasip1`).
- Triggers on push to `main` and on pull requests against `main`.
- Uses `actions/checkout@v4` per the issue's acceptance criteria.

Closes #3.

This lands the workflow proposed by @dobby-coder in https://github.com/encryption4all/ibs/issues/3#issuecomment-4380518495 — the agent verified locally but couldn't push it because the GitHub App lacks the `workflows` permission.

## Test plan
- [x] `cargo fmt -- --check`: clean
- [x] `cargo test --release --all-features` locally: 14 unit tests + 1 doctest pass
- [x] `cargo build --target wasm32-unknown-unknown --all-features --lib`: builds
- [x] `cargo build --target wasm32-wasip1 --all-features --lib`: builds
- [ ] All three CI jobs green on this branch