### PR TITLE
docs: extend CLAUDE.md with migrated agent notes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,52 @@
+
+---
+
+## Agent notes (migrated from the dobby memory repo)
+
+## Overview
+`encryption4all/ibs` is a pure-Rust `no_std` identity-based signature library.
+`gg.rs` implements Galindo-Garcia over Ristretto via `curve25519-dalek`.
+
+## Release process
+Manual release process, no automation.
+
+## CI
+`.github/workflows/ci.yml` jobs:
+- **Lint**: `cargo fmt -- --check` only, no clippy.
+- **Test**: `cargo test --release --all-features` on ubuntu / windows / macOS.
+- **no-std**: `cargo build --target {wasm32-unknown-unknown, wasm32-wasip1}
+  --all-features --lib`.
+- **PR Title**: Conventional Commit check via
+  `amannn/action-semantic-pull-request@v6`, `pr-title.yml`.
+
+Always run `cargo fmt --all -- --check` and a wasm32 build before pushing.
+
+## Dependency entanglement: curve25519-dalek gates the whole RustCrypto/rand stack
+- `curve25519-dalek` 4.1.3 (the last stable release as of writing) pins
+  `rand_core 0.6` and `digest 0.10`. `Scalar::random(r)`, `OsRng`, and
+  `Scalar::from_hash(h)` propagate those versions into `gg.rs`'s
+  `setup`/`keygen`/`sign` API and the `h_helper` Sha3_512 path.
+- Bumping `rand_core` (0.6 to 0.10), `rand` (0.8 to 0.10), `sha3` (0.10 to 0.11),
+  or `digest` (0.10 to 0.11) all require `curve25519-dalek` 5.x first.
+- **Flag: re-check whether `curve25519-dalek` 5.0 has shipped stable.** As of the
+  last check it was still pre-release (`5.0.0-rc.1`), and the whole stack had been
+  migrated in a draft PR pinned to `=5.0.0-rc.1`, pending the maintainer either
+  accepting an rc dependency or waiting for a stable release.
+- Safe to bump independently: `criterion` (dev-dep only, no API touch, e.g.
+  `std::hint::black_box` replacing the deprecated `criterion::black_box`).
+- Tombstone: stay on `bincode` 2.x; see `rules/bincode-3-tombstone.md`. Do not
+  bump to `bincode` 3.0.0.
+
+## RustCrypto 2025/26 + rand 0.10 API migration facts
+When this stack does move to `curve25519-dalek` 5.x + `rand_core` 0.10 + `digest`
+0.11:
+- `Shake128`/`Shake256` moved out of `sha3` into a standalone `shake` crate
+  (sha3 0.12 uses digest 0.11). Add `shake = { version = "0.1", default-features
+  = false }`; `Sha3_256`/`Sha3_512`/`Digest` stay in `sha3`.
+- `rand_core 0.10`: `RngCore` is deprecated (use `Rng`); `CryptoRng: Rng` now, so
+  bounding `<R: CryptoRng>` alone suffices. `dalek 5`'s `Scalar::random<R:
+  CryptoRng>` follows this.
+- `OsRng` was removed from `rand_core` (its `SysRng` successor only implements
+  the fallible `TryRng`/`TryCryptoRng`, not `CryptoRng`). Use `rand::rng()`
+  (`ThreadRng`, an infallible `CryptoRng`) in tests/bench/doctests;
+  `rand::thread_rng()` is also removed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,8 +36,10 @@ Always run `cargo fmt --all -- --check` and a wasm32 build before pushing.
   lands; nothing else in the stack needs to change for that.
 - Safe to bump independently: `criterion` (dev-dep only, no API touch, e.g.
   `std::hint::black_box` replacing the deprecated `criterion::black_box`).
-- Tombstone: stay on `bincode` 2.x; see `rules/bincode-3-tombstone.md`. Do not
-  bump to `bincode` 3.0.0.
+- Serialization (dev-dep only): tests use the `bincode-next` fork, pinned to
+  `=3.0.0-rc.13`; `gg.rs` calls `bincode_next::`. This migrated off the original
+  `bincode` crate in commit `fdc9bac`. Tombstone: that original `bincode` crate
+  is unmaintained, so do not switch back to it.
 
 ## RustCrypto 2025/26 + rand 0.10 API migration facts
 This stack moved to `curve25519-dalek` 5.x + `rand_core` 0.10 + `digest` 0.11 in

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,31 +22,33 @@ Manual release process, no automation.
 Always run `cargo fmt --all -- --check` and a wasm32 build before pushing.
 
 ## Dependency entanglement: curve25519-dalek gates the whole RustCrypto/rand stack
-- `curve25519-dalek` 4.1.3 (the last stable release as of writing) pins
-  `rand_core 0.6` and `digest 0.10`. `Scalar::random(r)`, `OsRng`, and
-  `Scalar::from_hash(h)` propagate those versions into `gg.rs`'s
-  `setup`/`keygen`/`sign` API and the `h_helper` Sha3_512 path.
-- Bumping `rand_core` (0.6 to 0.10), `rand` (0.8 to 0.10), `sha3` (0.10 to 0.11),
-  or `digest` (0.10 to 0.11) all require `curve25519-dalek` 5.x first.
-- **Flag: re-check whether `curve25519-dalek` 5.0 has shipped stable.** As of the
-  last check it was still pre-release (`5.0.0-rc.1`), and the whole stack had been
-  migrated in a draft PR pinned to `=5.0.0-rc.1`, pending the maintainer either
-  accepting an rc dependency or waiting for a stable release.
+- `curve25519-dalek` is pinned to `=5.0.0-rc.1` (features `alloc`,
+  `precomputed-tables`, `digest`, `rand_core`), which pins `rand_core 0.10` and
+  `digest 0.11`. `Scalar::random(r)` and `Scalar::from_hash(h)` propagate those
+  versions into `gg.rs`'s `setup`/`keygen`/`sign` API (all `<R: CryptoRng>`) and
+  the `h_helper` Sha3_512 path.
+- Current pins: `rand_core 0.10`, `sha3 0.12`, `shake 0.1`, `rand 0.10` (dev-dep).
+  Bumping any of these was gated on `curve25519-dalek` 5.x; that migration landed
+  in main via #24 (commit `0ebff0e`, `chore(deps): migrate to curve25519-dalek
+  5.0, rand 0.10, sha3 0.12`).
+- **Caveat: still on the release candidate.** `curve25519-dalek` 5.0 has not
+  shipped stable, so the pin is `=5.0.0-rc.1`. Re-pin to the stable `5.0` once it
+  lands; nothing else in the stack needs to change for that.
 - Safe to bump independently: `criterion` (dev-dep only, no API touch, e.g.
   `std::hint::black_box` replacing the deprecated `criterion::black_box`).
 - Tombstone: stay on `bincode` 2.x; see `rules/bincode-3-tombstone.md`. Do not
   bump to `bincode` 3.0.0.
 
 ## RustCrypto 2025/26 + rand 0.10 API migration facts
-When this stack does move to `curve25519-dalek` 5.x + `rand_core` 0.10 + `digest`
-0.11:
+This stack moved to `curve25519-dalek` 5.x + `rand_core` 0.10 + `digest` 0.11 in
+#24. The facts that made that migration work, kept here for the next bump:
 - `Shake128`/`Shake256` moved out of `sha3` into a standalone `shake` crate
-  (sha3 0.12 uses digest 0.11). Add `shake = { version = "0.1", default-features
+  (sha3 0.12 uses digest 0.11). Hence `shake = { version = "0.1", default-features
   = false }`; `Sha3_256`/`Sha3_512`/`Digest` stay in `sha3`.
 - `rand_core 0.10`: `RngCore` is deprecated (use `Rng`); `CryptoRng: Rng` now, so
   bounding `<R: CryptoRng>` alone suffices. `dalek 5`'s `Scalar::random<R:
   CryptoRng>` follows this.
 - `OsRng` was removed from `rand_core` (its `SysRng` successor only implements
-  the fallible `TryRng`/`TryCryptoRng`, not `CryptoRng`). Use `rand::rng()`
-  (`ThreadRng`, an infallible `CryptoRng`) in tests/bench/doctests;
-  `rand::thread_rng()` is also removed.
+  the fallible `TryRng`/`TryCryptoRng`, not `CryptoRng`). Tests/bench/doctests use
+  `rand::rng()` (`ThreadRng`, an infallible `CryptoRng`); `rand::thread_rng()` is
+  also removed.


### PR DESCRIPTION
Extends the existing `CLAUDE.md` with agent notes migrated from the private dobby memory repo (`encryption4all/dobby`, formerly `repos/<this-repo>/`), verified against the current state of the code before migration.

Going forward this file is the single home for durable repo knowledge: dobby updates it in the same PR whenever it learns something worth keeping.